### PR TITLE
fix: close statement after read result from connection

### DIFF
--- a/pkg/driver/client.go
+++ b/pkg/driver/client.go
@@ -487,6 +487,21 @@ func (conn *BackendConnection) WriteComFieldList(table string, wildcard string) 
 	return nil
 }
 
+// WriteComStmtClose close statement
+func (conn *BackendConnection) WriteComStmtClose(statementID uint32) (err error) {
+	// This is a new command, need to reset the Sequence.
+	conn.ResetSequence()
+
+	data := conn.StartEphemeralPacket(4 + 1)
+	data[0] = constant.ComStmtClose
+	misc.WriteUint32(data, 1, statementID)
+	if err := conn.WriteEphemeralPacket(); err != nil {
+		return err2.NewSQLError(constant.CRServerGone, constant.SSUnknownSQLState, err.Error())
+	}
+
+	return conn.readResultOK()
+}
+
 // ReadQueryResult gets the result from the last written query.
 func (conn *BackendConnection) ReadQueryResult(wantFields bool) (result *mysql.Result, more bool, warnings uint16, err error) {
 	// Get the result.

--- a/pkg/driver/statement.go
+++ b/pkg/driver/statement.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/cectc/dbpack/pkg/constant"
 	"github.com/cectc/dbpack/pkg/errors"
+	"github.com/cectc/dbpack/pkg/log"
 	"github.com/cectc/dbpack/pkg/misc"
 	"github.com/cectc/dbpack/pkg/mysql"
 	"github.com/cectc/dbpack/pkg/packet"
@@ -414,6 +415,12 @@ func (stmt *BackendStatement) queryArgs(args []interface{}) (*mysql.Result, uint
 }
 
 func (stmt *BackendStatement) exec(args []byte) (*mysql.Result, uint16, error) {
+	defer func() {
+		if err := stmt.conn.WriteComStmtClose(stmt.id); err != nil {
+			log.Error(err)
+		}
+	}()
+
 	args[1] = byte(stmt.id)
 	args[2] = byte(stmt.id >> 8)
 	args[3] = byte(stmt.id >> 16)


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/<issueID>

### Ⅰ. Describe what this PR did
If not close statement, you might encounter the upper limit enforced by the [max_prepared_stmt_count](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_prepared_stmt_count) system variable.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
