### PR TITLE
fixbug: Ping should put resource back to the pool

### DIFF
--- a/pkg/sql/db.go
+++ b/pkg/sql/db.go
@@ -343,6 +343,7 @@ func (db *DB) ping() (err error) {
 	if err != nil {
 		return err
 	}
+	defer db.pool.Put(r)
 	conn := r.(*driver.BackendConnection)
 	err = conn.Ping(context.Background())
 	return


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/<issueID>

### Ⅰ. Describe what this PR did
I found dbpack won\`t work as mysql proxy when waiting for a few minutes, and the ping would get the resource from the pool but not put it back to the pool. If the default config capacity is 30 and ping_interval is 20s, the dbpack won\`t work after 30*20s=600s for the pool exhausted.

### Ⅱ. Does this pull request fix one issue?
no.

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
I had test it on my local enviroment.

### Ⅳ. Describe how to verify it
Run the sample, and wait for more than 10 minutes.

### Ⅴ. Special notes for reviews
nothing.