### PR TITLE
refactor: ignore case of http request path

### DIFF
--- a/pkg/filter/dt/filter_http.go
+++ b/pkg/filter/dt/filter_http.go
@@ -59,11 +59,13 @@ func (factory *httpFactory) NewFilter(config map[string]interface{}) (proto.Filt
 	}
 
 	for _, ti := range filterConfig.TransactionInfos {
-		f.transactionInfos[ti.RequestPath] = ti
+		f.transactionInfos[strings.ToLower(ti.RequestPath)] = ti
+		log.Debugf("proxy %s, will create global transaction, put xid into request header", ti.RequestPath)
 	}
 
 	for _, r := range filterConfig.TCCResources {
-		f.tccResources[r.PrepareRequestPath] = r
+		f.tccResources[strings.ToLower(r.PrepareRequestPath)] = r
+		log.Debugf("proxy %s, will register branch transaction", r.PrepareRequestPath)
 	}
 	return f, nil
 }


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/<issueID>

### Ⅰ. Describe what this PR did

get transactionInfo、tccResource with lowercase, so put transactionInfo into transactionInfos map should cast to lowercase, put tccResource into tccResources map should cast to lowercase.
```
transactionInfo, found := f.transactionInfos[strings.ToLower(string(path))]
tccResource, exists := f.tccResources[strings.ToLower(string(path))]
```


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
