### PR TITLE
refactor: cmd dir layout

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -39,6 +39,7 @@ import (
 	"github.com/cectc/dbpack/pkg/filter"
 	_ "github.com/cectc/dbpack/pkg/filter/dt"
 	_ "github.com/cectc/dbpack/pkg/filter/metrics"
+	dbpackHttp "github.com/cectc/dbpack/pkg/http"
 	"github.com/cectc/dbpack/pkg/listener"
 	"github.com/cectc/dbpack/pkg/log"
 	"github.com/cectc/dbpack/pkg/proto"
@@ -196,7 +197,7 @@ func initServer(ctx context.Context, lis net.Listener) {
 		<-ctx.Done()
 		lis.Close()
 	}()
-	handler, err := registerRoutes()
+	handler, err := dbpackHttp.RegisterRoutes()
 	if err != nil {
 		log.Fatalf("failed to init handler: %+v", err)
 		return

--- a/pkg/http/healthcheck.go
+++ b/pkg/http/healthcheck.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package main
+package http
 
 import (
 	"net/http"

--- a/pkg/http/metrics.go
+++ b/pkg/http/metrics.go
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-package main
+package http
 
 import (
-	"net/http"
-
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func registerRoutes() (http.Handler, error) {
-	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
-	// Add healthcheck router
-	registerHealthCheckRouter(router)
-
-	// Add server metrics router
-	registerMetricsRouter(router)
-
-	return router, nil
+// registerMetricsRouter - add handler functions for metrics.
+func registerMetricsRouter(router *mux.Router) {
+	// metrics router
+	router.Path("/metrics").Handler(promhttp.Handler())
 }

--- a/pkg/http/routes.go
+++ b/pkg/http/routes.go
@@ -14,15 +14,21 @@
  * limitations under the License.
  */
 
-package main
+package http
 
 import (
+	"net/http"
+
 	"github.com/gorilla/mux"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-// registerMetricsRouter - add handler functions for metrics.
-func registerMetricsRouter(router *mux.Router) {
-	// metrics router
-	router.Path("/metrics").Handler(promhttp.Handler())
+func RegisterRoutes() (http.Handler, error) {
+	router := mux.NewRouter().SkipClean(true).UseEncodedPath()
+	// Add healthcheck router
+	registerHealthCheckRouter(router)
+
+	// Add server metrics router
+	registerMetricsRouter(router)
+
+	return router, nil
 }


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/<issueID>

### Ⅰ. Describe what this PR did

when exec `go run cmd/cmd.go` the compiler only load `cmd.go` file, so it will report `registerRoutes is undefined`. 

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
