### PR TITLE
fix the lock key format, and the spelling mistake

### DIFF
--- a/pkg/dt/schema/table_records.go
+++ b/pkg/dt/schema/table_records.go
@@ -68,7 +68,7 @@ func BuildLockKey(lockKeyRecords *TableRecords) string {
 	fields := lockKeyRecords.PKFields()
 	length := len(fields)
 	for i, field := range fields {
-		sb.WriteString(fmt.Sprintf("%s", field.Value))
+		sb.WriteString(fmt.Sprintf("%v", field.Value))
 		if i < length-1 {
 			sb.WriteByte(',')
 		}

--- a/pkg/http/healthcheck.go
+++ b/pkg/http/healthcheck.go
@@ -40,7 +40,7 @@ func readinessHandler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
-	err := dbm.(*resource.DBManager).GetResoucePoolStatus()
+	err := dbm.(*resource.DBManager).GetResourcePoolStatus()
 	if err != nil {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return

--- a/pkg/resource/data_source.go
+++ b/pkg/resource/data_source.go
@@ -87,7 +87,7 @@ func (manager *DBManager) GetDB(name string) proto.DB {
 	return manager.resourcePools[name]
 }
 
-func (manager *DBManager) GetResoucePoolStatus() error {
+func (manager *DBManager) GetResourcePoolStatus() error {
 	for _, dataSource := range manager.resourcePools {
 		db := dataSource.(*sql.DB)
 		if err := db.TestConn(); err != nil {


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/<issueID>

### Ⅰ. Describe what this PR did
The format of the lock key was like \`order\`.\`so_item\`:%!s(int64=2149238595) when I ran the sample, because the value of primary key is int. Replace %s to %v for fitting the interface type. And a spelling mistake fixed.

### Ⅱ. Does this pull request fix one issue?
No

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Not need

### Ⅳ. Describe how to verify it
Run the sample, and watch the log.

### Ⅴ. Special notes for reviews
No.