### PR TITLE
fix: rollback when global session timeout

### DIFF
--- a/pkg/errors/dt.go
+++ b/pkg/errors/dt.go
@@ -20,6 +20,7 @@ import "errors"
 
 var (
 	GlobalTransactionNotActive     = errors.New("global session not active")
+	GlobalTransactionFinished      = errors.New("global session finished")
 	CouldNotFoundGlobalTransaction = errors.New("could not found global transaction")
 	CouldNotFoundBranchTransaction = errors.New("could not found branch transaction")
 	BranchLockAcquireFailed        = errors.New("branch lock acquire failed")

--- a/pkg/listener/http.go
+++ b/pkg/listener/http.go
@@ -104,6 +104,11 @@ func (l *HttpListener) Listen() {
 		}
 		if err := l.doPostFilter(ctx); err != nil {
 			log.Error(err)
+			ctx.Response.Reset()
+			ctx.SetStatusCode(500)
+			if _, err = ctx.WriteString(fmt.Sprintf(`{"success":false,"message":"%s"}`, err.Error())); err != nil {
+				log.Error(err)
+			}
 		}
 	}); err != nil {
 		log.Error(err)


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/145

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
test result:
```
curl -XPOST http://localhost:13000/v1/order/create      
// 60 seconds later                                                                                                                                              
{"success":false,"message":"global session finished"}
```

### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
