### PR TITLE
feat: audit log filter

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cectc/dbpack/pkg/dt/storage/etcd"
 	"github.com/cectc/dbpack/pkg/executor"
 	"github.com/cectc/dbpack/pkg/filter"
+	_ "github.com/cectc/dbpack/pkg/filter/audit_log"
 	_ "github.com/cectc/dbpack/pkg/filter/dt"
 	_ "github.com/cectc/dbpack/pkg/filter/metrics"
 	dbpackHttp "github.com/cectc/dbpack/pkg/http"

--- a/docker/conf/config_sdb.yaml
+++ b/docker/conf/config_sdb.yaml
@@ -26,16 +26,30 @@ data_source_cluster:
     filters:
       - metricFilter
       - mysqlDTFilter
+      - auditLogFilter
 
 filters:
+  - name: metricFilter
+    kind: ConnectionMetricFilter
   - name: mysqlDTFilter
     kind: MysqlDistributedTransaction
     conf:
       appid: svc
       lock_retry_interval: 50ms
       lock_retry_times: 30
-  - name: metricFilter
-    kind: ConnectionMetricFilter
+  - name: auditLogFilter
+    kind: AuditLogFilter
+    conf:
+      audit_log_dir: /var/log/dbpack/
+      # unit MB
+      max_size: 300
+      # unit Day
+      max_age: 28
+      # maximum number of old log files to retain
+      max_backups: 1
+      # determines if the rotated log files should be compressed using gzip
+      compress: true
+      record_before: true
 
 distributed_transaction:
   appid: svc

--- a/docker/docker-compose-sdb.yaml
+++ b/docker/docker-compose-sdb.yaml
@@ -41,6 +41,7 @@ services:
     volumes:
       - ./conf/config_sdb.yaml:/config.yaml
       - ./scripts/wait-for-mysql.sh:/wait-for-mysql.sh
+      - /root/:/var/log/:rw
     depends_on:
       - etcd
       - mysql

--- a/go.mod
+++ b/go.mod
@@ -57,5 +57,6 @@ require (
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	google.golang.org/protobuf v1.27.1
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	k8s.io/apimachinery v0.23.5
 )

--- a/pkg/driver/client.go
+++ b/pkg/driver/client.go
@@ -520,7 +520,9 @@ func (conn *BackendConnection) ReadQueryResult(wantFields bool) (result *mysql.R
 	}
 
 	result = &mysql.Result{
-		Fields: make([]*mysql.Field, colNumber),
+		AffectedRows: affectedRows,
+		InsertId:     lastInsertID,
+		Fields:       make([]*mysql.Field, colNumber),
 	}
 
 	// Read column headers. One packet per column.

--- a/pkg/executor/single_db.go
+++ b/pkg/executor/single_db.go
@@ -199,7 +199,7 @@ func (executor *SingleDBExecutor) ExecutorComQuery(ctx context.Context, sql stri
 
 func (executor *SingleDBExecutor) ExecutorComStmtExecute(ctx context.Context, stmt *proto.Stmt) (proto.Result, uint16, error) {
 	connectionID := proto.ConnectionID(ctx)
-	log.Debugf("connectionID: %d, prepare: %s", connectionID, stmt.PrepareStmt)
+	log.Debugf("connectionID: %d, prepare: %s", connectionID, stmt.SqlText)
 	txi, ok := executor.localTransactionMap.Load(connectionID)
 	if ok {
 		tx := txi.(proto.Tx)

--- a/pkg/filter/audit_log/filter.go
+++ b/pkg/filter/audit_log/filter.go
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2022 CECTC, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package audit_log
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/golang-module/carbon"
+	"github.com/pkg/errors"
+	"gopkg.in/natefinch/lumberjack.v2"
+
+	"github.com/cectc/dbpack/pkg/constant"
+	"github.com/cectc/dbpack/pkg/filter"
+	"github.com/cectc/dbpack/pkg/log"
+	"github.com/cectc/dbpack/pkg/proto"
+	"github.com/cectc/dbpack/third_party/parser/ast"
+)
+
+const (
+	auditLogFilter    = "AuditLogFilter"
+	defaultMaxSize    = 500
+	defaultMaxBackups = 1
+	defaultMaxAge     = 30
+)
+
+type _factory struct {
+}
+
+func (factory *_factory) NewFilter(config map[string]interface{}) (proto.Filter, error) {
+	var (
+		err          error
+		content      []byte
+		filterConfig *AuditLogFilterConfig
+	)
+
+	if content, err = json.Marshal(config); err != nil {
+		return nil, errors.Wrap(err, "marshal audit log filter config failed.")
+	}
+	if err = json.Unmarshal(content, &filterConfig); err != nil {
+		log.Errorf("unmarshal audit log filter failed, %s", err)
+		return nil, err
+	}
+	if filterConfig.MaxSize == 0 {
+		filterConfig.MaxSize = defaultMaxSize
+	}
+	if filterConfig.MaxBackups == 0 {
+		filterConfig.MaxBackups = defaultMaxBackups
+	}
+	if filterConfig.MaxAge == 0 {
+		filterConfig.MaxAge = defaultMaxAge
+	}
+	logger := &lumberjack.Logger{
+		Filename:   auditLogFile(filterConfig.AuditLogDir),
+		MaxSize:    filterConfig.MaxSize,
+		MaxBackups: filterConfig.MaxBackups,
+		MaxAge:     filterConfig.MaxAge,
+		Compress:   filterConfig.Compress,
+	}
+	return &_filter{recordBefore: filterConfig.RecordBefore, log: logger}, nil
+}
+
+type AuditLogFilterConfig struct {
+	AuditLogDir string `json:"audit_log_dir" yaml:"audit_log_dir"`
+	// MaxSize is the maximum size in megabytes of the log file before it gets rotated
+	MaxSize int `json:"max_size" yaml:"max_size"`
+	// MaxAge is the maximum number of days to retain old log files
+	MaxAge int `json:"max_age" yaml:"max_age"`
+	// MaxBackups maximum number of old log files to retain
+	MaxBackups int `json:"max_backups" yaml:"max_backups"`
+	// Compress determines if the rotated log files should be compressed using gzip
+	Compress bool `json:"compress" yaml:"compress"`
+	// RecordBefore define whether to log before or after sql execution
+	RecordBefore bool `json:"record_before" yaml:"record_before"`
+}
+
+type _filter struct {
+	recordBefore bool
+	log          *lumberjack.Logger
+}
+
+func (f *_filter) GetKind() string {
+	return auditLogFilter
+}
+
+func (f *_filter) PreHandle(ctx context.Context, conn proto.Connection) error {
+	if !f.recordBefore {
+		return nil
+	}
+	userName := proto.UserName(ctx)
+	remoteAddr := proto.RemoteAddr(ctx)
+	connectionID := proto.ConnectionID(ctx)
+	commandType := proto.CommandType(ctx)
+	sqlText := proto.SqlText(ctx)
+
+	var (
+		commandTypeStr string
+		args           strings.Builder
+		stmt           ast.Node
+	)
+	args.WriteByte('[')
+	switch commandType {
+	case constant.ComQuery:
+		commandTypeStr = "COM_QUERY"
+		stmt = proto.QueryStmt(ctx)
+	case constant.ComStmtExecute:
+		commandTypeStr = "COM_STMT_EXECUTE"
+		statement := proto.PrepareStmt(ctx)
+		stmt = statement.StmtNode
+		for i := 0; i < len(statement.BindVars); i++ {
+			parameterID := fmt.Sprintf("v%d", i+1)
+			param := statement.BindVars[parameterID]
+			switch arg := param.(type) {
+			case []byte, string:
+				args.WriteString(fmt.Sprintf("'%s'", arg))
+			case nil:
+				args.WriteString("NULL")
+			default:
+				args.WriteString(fmt.Sprintf("'%v'", arg))
+			}
+			if i < len(statement.BindVars)-1 {
+				args.WriteByte(' ')
+			}
+		}
+	default:
+		return nil
+	}
+	args.WriteByte(']')
+
+	var command string
+	switch stmt.(type) {
+	case *ast.DeleteStmt:
+		command = "DELETE"
+	case *ast.InsertStmt:
+		command = "INSERT"
+	case *ast.UpdateStmt:
+		command = "UPDATE"
+	case *ast.SelectStmt:
+		command = "SELECT"
+	default:
+	}
+
+	if _, err := f.log.Write([]byte(fmt.Sprintf("%s,%s,%s,%v,%s,%s,%s,%s,0\n", carbon.Now(), userName, remoteAddr, connectionID,
+		commandTypeStr, command, sqlText, args.String()))); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *_filter) PostHandle(ctx context.Context, result proto.Result, conn proto.Connection) error {
+	if f.recordBefore {
+		return nil
+	}
+	userName := proto.UserName(ctx)
+	remoteAddr := proto.RemoteAddr(ctx)
+	connectionID := proto.ConnectionID(ctx)
+	commandType := proto.CommandType(ctx)
+	sqlText := proto.SqlText(ctx)
+
+	var (
+		commandTypeStr string
+		args           strings.Builder
+		stmt           ast.Node
+	)
+	args.WriteByte('[')
+	switch commandType {
+	case constant.ComQuery:
+		commandTypeStr = "COM_QUERY"
+		stmt = proto.QueryStmt(ctx)
+	case constant.ComStmtExecute:
+		commandTypeStr = "COM_STMT_EXECUTE"
+		statement := proto.PrepareStmt(ctx)
+		stmt = statement.StmtNode
+		for i := 0; i < len(statement.BindVars); i++ {
+			parameterID := fmt.Sprintf("v%d", i+1)
+			param := statement.BindVars[parameterID]
+			switch arg := param.(type) {
+			case []byte, string:
+				args.WriteString(fmt.Sprintf("'%s'", arg))
+			case nil:
+				args.WriteString("NULL")
+			default:
+				args.WriteString(fmt.Sprintf("'%v'", arg))
+			}
+			if i < len(statement.BindVars)-1 {
+				args.WriteByte(' ')
+			}
+		}
+	default:
+		return nil
+	}
+	args.WriteByte(']')
+
+	var command string
+	switch stmt.(type) {
+	case *ast.DeleteStmt:
+		command = "DELETE"
+	case *ast.InsertStmt:
+		command = "INSERT"
+	case *ast.UpdateStmt:
+		command = "UPDATE"
+	case *ast.SelectStmt:
+		command = "SELECT"
+	default:
+	}
+
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if _, err := f.log.Write([]byte(fmt.Sprintf("%s,%s,%s,%v,%s,%s,%s,%s,%v\n", carbon.Now(), userName, remoteAddr, connectionID,
+		commandTypeStr, command, sqlText, args.String(), affected))); err != nil {
+		return err
+	}
+	return nil
+}
+
+func auditLogFile(dir string) string {
+	return filepath.Join(dir, "audit.log")
+}
+
+func init() {
+	filter.RegistryFilterFactory(auditLogFilter, &_factory{})
+}

--- a/pkg/filter/dt/exec/prepare_global_lock_test.go
+++ b/pkg/filter/dt/exec/prepare_global_lock_test.go
@@ -215,7 +215,7 @@ func TestPrepareGlobalLock(t *testing.T) {
 			ctx := proto.WithCommandType(context.Background(), constant.ComStmtExecute)
 			protoStmt := &proto.Stmt{
 				StatementID: 1,
-				PrepareStmt: c.sql,
+				SqlText:     c.sql,
 				ParamsCount: 1,
 				ParamData:   nil,
 				ParamsType:  nil,

--- a/pkg/filter/dt/exec/prepare_select_for_update_test.go
+++ b/pkg/filter/dt/exec/prepare_select_for_update_test.go
@@ -76,7 +76,7 @@ func TestPrepareSelectForUpdate(t *testing.T) {
 			ctx := proto.WithCommandType(context.Background(), constant.ComStmtExecute)
 			protoStmt := &proto.Stmt{
 				StatementID: 1,
-				PrepareStmt: c.sql,
+				SqlText:     c.sql,
 				ParamsCount: 1,
 				ParamData:   nil,
 				ParamsType:  nil,

--- a/pkg/filter/dt/exec/query_global_lock_test.go
+++ b/pkg/filter/dt/exec/query_global_lock_test.go
@@ -106,7 +106,7 @@ func TestQueryGlobalLock(t *testing.T) {
 			ctx := proto.WithCommandType(context.Background(), constant.ComStmtExecute)
 			protoStmt := &proto.Stmt{
 				StatementID: 1,
-				PrepareStmt: c.sql,
+				SqlText:     c.sql,
 				ParamsCount: 1,
 				ParamData:   nil,
 				ParamsType:  nil,

--- a/pkg/filter/dt/exec/query_select_for_update_test.go
+++ b/pkg/filter/dt/exec/query_select_for_update_test.go
@@ -76,7 +76,7 @@ func TestQuerySelectForUpdate(t *testing.T) {
 			ctx := proto.WithCommandType(context.Background(), constant.ComStmtExecute)
 			protoStmt := &proto.Stmt{
 				StatementID: 1,
-				PrepareStmt: c.sql,
+				SqlText:     c.sql,
 				ParamsCount: 1,
 				ParamData:   nil,
 				ParamsType:  nil,

--- a/pkg/proto/context.go
+++ b/pkg/proto/context.go
@@ -36,6 +36,8 @@ type (
 	keyQueryStmt    struct{}
 	keyPrepareStmt  struct{}
 	keyVariableMap  struct{}
+	keySqlText      struct{}
+	keyRemoteAddr   struct{}
 )
 
 type cFlag uint8
@@ -116,7 +118,7 @@ func CommandType(ctx context.Context) byte {
 	return 0
 }
 
-// WithQueryStmt bind query stmt
+// WithQueryStmt binds query stmt
 func WithQueryStmt(ctx context.Context, stmt ast.StmtNode) context.Context {
 	return context.WithValue(ctx, keyQueryStmt{}, stmt)
 }
@@ -130,7 +132,7 @@ func QueryStmt(ctx context.Context) ast.StmtNode {
 	return nil
 }
 
-// WithPrepareStmt bind prepare stmt
+// WithPrepareStmt binds prepare stmt
 func WithPrepareStmt(ctx context.Context, stmt *Stmt) context.Context {
 	return context.WithValue(ctx, keyPrepareStmt{}, stmt)
 }
@@ -166,6 +168,34 @@ func Variable(ctx context.Context, key string) interface{} {
 		return variables[key]
 	}
 	return nil
+}
+
+// WithSqlText binds sql text
+func WithSqlText(ctx context.Context, sqlText string) context.Context {
+	return context.WithValue(ctx, keySqlText{}, sqlText)
+}
+
+// SqlText extracts sql text
+func SqlText(ctx context.Context) string {
+	sqlText, ok := ctx.Value(keySqlText{}).(string)
+	if ok {
+		return sqlText
+	}
+	return ""
+}
+
+// WithRemoteAddr binds remote address
+func WithRemoteAddr(ctx context.Context, remoteAddr string) context.Context {
+	return context.WithValue(ctx, keyRemoteAddr{}, remoteAddr)
+}
+
+// RemoteAddr extracts remote addr
+func RemoteAddr(ctx context.Context) string {
+	remoteAddr, ok := ctx.Value(keyRemoteAddr{}).(string)
+	if ok {
+		return remoteAddr
+	}
+	return ""
 }
 
 func hasFlag(ctx context.Context, flag cFlag) bool {

--- a/pkg/proto/data.go
+++ b/pkg/proto/data.go
@@ -71,7 +71,7 @@ type (
 	// Stmt is a buffer used for store prepare statement meta data
 	Stmt struct {
 		StatementID uint32
-		PrepareStmt string
+		SqlText     string
 		ParamsCount uint16
 		ParamData   []byte
 		ParamsType  []int32

--- a/test/cmd/test_single_db.sh
+++ b/test/cmd/test_single_db.sh
@@ -6,7 +6,8 @@ sleep 90
 
 go clean -testcache
 go test -tags integration -v ./test/sdb/
-
+echo "-----------------------------dbpack log-----------------------------"
 docker logs dbpack
-
+echo "-----------------------------audit log-----------------------------"
+cat /root/dbpack/audit.log
 docker-compose -f docker/docker-compose-sdb.yaml down

--- a/test/sdb/distributed_transaction_test.go
+++ b/test/sdb/distributed_transaction_test.go
@@ -63,7 +63,7 @@ func (suite *_DistributedTransactionSuite) SetupSuite() {
 		RetryDeadThreshold:               130000,
 		RollbackRetryTimeoutUnlockEnable: true,
 		EtcdConfig: clientv3.Config{
-			Endpoints: []string{"localhost:2379", "localhost:2378", "localhost:2377"},
+			Endpoints: []string{"localhost:2379"},
 		},
 	}
 


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/103

### Ⅰ. Describe what this PR did
AuditLog Format:
```
[timestamp],[username],[ip address],[connection id],[command type],[command],[sql text],[args],[affected row]
``` 
command type has only two values: `COM_QUERY`、`COM_STMT_EXECUTE`.
command has five values: `INSERT`、`DELETE`、`UPDATE`、`SELECT` and empty
only when command type is `COM_STMT_EXECUTE`, args have value.

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it
The logs recorded are as follows:
```
2022-06-14 07:15:44,dksl,172.18.0.1:60372,1,COM_QUERY,,SET NAMES utf8mb4,[],0
2022-06-14 07:15:45,dksl,172.18.0.1:60372,1,COM_STMT_EXECUTE,INSERT,INSERT INTO employees ( emp_no, birth_date, first_name, last_name, gender, hire_date ) VALUES (?, ?, ?, ?, ?, ?),['100000' '1992-01-07' 'scott' 'lewis' 'M' '2014-09-01'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60372,1,COM_STMT_EXECUTE,DELETE,DELETE FROM employees WHERE emp_no = ?,['100000'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60372,1,COM_STMT_EXECUTE,INSERT,INSERT INTO employees ( emp_no, birth_date, first_name, last_name, gender, hire_date ) VALUES (?, ?, ?, ?, ?, ?),['100001' '1992-01-07' 'scott' 'lewis' 'M' '2014-09-01'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60372,1,COM_STMT_EXECUTE,SELECT,SELECT emp_no, birth_date, first_name, last_name, gender, hire_date FROM employees WHERE emp_no = ?,['100001'],0
2022-06-14 07:15:45,dksl,172.18.0.1:60384,2,COM_QUERY,,SET NAMES utf8mb4,[],0
2022-06-14 07:15:45,dksl,172.18.0.1:60384,2,COM_STMT_EXECUTE,UPDATE,UPDATE employees set last_name = ? where emp_no = ?,['louis' '100001'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60384,2,COM_STMT_EXECUTE,DELETE,DELETE FROM employees WHERE emp_no = ?,['100001'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60392,3,COM_QUERY,,SET NAMES utf8mb4,[],0
2022-06-14 07:15:45,dksl,172.18.0.1:60392,3,COM_STMT_EXECUTE,INSERT,INSERT INTO employees ( id, emp_no, birth_date, first_name, last_name, gender, hire_date ) VALUES (?, ?, ?, ?, ?, ?, ?),['1' '100001' '1992-06-04' 'jane' 'watson' 'F' '2013-06-01'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60392,3,COM_STMT_EXECUTE,INSERT,INSERT INTO departments ( id, dept_no, dept_name ) VALUES (?, ?, ?),['1' '1001' 'sales'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60392,3,COM_STMT_EXECUTE,INSERT,INSERT INTO dept_emp ( id, emp_no, dept_no, from_date, to_date ) VALUES (?, ?, ?, ?, ?),['1' '100001' '1001' '2020-01-01' '2022-01-01'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60392,3,COM_STMT_EXECUTE,INSERT,INSERT INTO salaries ( id, emp_no, salary, from_date, to_date ) VALUES (?, ?, ?, ?, ?),['1' '100001' '8000' '2020-01-01' '2025-01-01'],1
2022-06-14 07:15:45,dksl,172.18.0.1:60394,4,COM_QUERY,,SET NAMES utf8mb4,[],0
2022-06-14 07:15:45,dksl,172.18.0.1:60394,4,COM_QUERY,INSERT,INSERT INTO dept_emp ( id, emp_no, dept_no, from_date, to_date ) VALUES (2, 100002, 1002, '2020-01-01', '2022-01-01'),[],1
2022-06-14 07:15:45,dksl,172.18.0.1:60394,4,COM_QUERY,INSERT,INSERT INTO salaries ( id, emp_no, salary, from_date, to_date ) VALUES (2, 100002, 8000, '2020-01-01', '2025-01-01'),[],1
```

### Ⅴ. Special notes for reviews
