### PR TITLE
refactor: support manipulating the same data in different transaction…

### DIFF
--- a/pkg/dt/distributed_transaction_manger.go
+++ b/pkg/dt/distributed_transaction_manger.go
@@ -165,6 +165,10 @@ func (manager *DistributedTransactionManager) IsLockable(ctx context.Context, re
 	return manager.storageDriver.IsLockable(ctx, resourceID, lockKey)
 }
 
+func (manager *DistributedTransactionManager) IsLockableWithXID(ctx context.Context, resourceID, lockKey, xid string) (bool, error) {
+	return manager.storageDriver.IsLockableWithXID(ctx, resourceID, lockKey, xid)
+}
+
 func (manager *DistributedTransactionManager) branchCommit(bs *api.BranchSession) (api.BranchSession_BranchStatus, error) {
 	var (
 		status api.BranchSession_BranchStatus

--- a/pkg/dt/storage/etcd/etcd.go
+++ b/pkg/dt/storage/etcd/etcd.go
@@ -130,7 +130,7 @@ func (s *store) AddBranchSession(ctx context.Context, branchSession *api.BranchS
 
 	if branchSession.Type == api.AT && branchSession.LockKey != "" {
 		rowKeys := misc.CollectRowKeys(branchSession.LockKey, branchSession.ResourceID)
-		rowKeys, err = s.filterRowKey(ctx, rowKeys, branchSession.XID)
+		rowKeys, err = s.filterRowKeys(ctx, rowKeys, branchSession.XID)
 		if err != nil {
 			return err
 		}
@@ -523,7 +523,7 @@ func notFound(key string) clientv3.Cmp {
 	return clientv3.Compare(clientv3.ModRevision(key), "=", 0)
 }
 
-func (s *store) filterRowKey(ctx context.Context, rowKeys []string, xid string) ([]string, error) {
+func (s *store) filterRowKeys(ctx context.Context, rowKeys []string, xid string) ([]string, error) {
 	var result []string
 	rowKeyValues, err := s.getRowKeyValues(ctx, rowKeys)
 	if err != nil {

--- a/pkg/dt/storage/etcd/etcd.go
+++ b/pkg/dt/storage/etcd/etcd.go
@@ -334,7 +334,8 @@ func (s *store) ListBranchSession(ctx context.Context, applicationID string) ([]
 		return nil, nil
 	}
 	var result []*api.BranchSession
-	for _, kv := range resp.Kvs {
+	for i := len(resp.Kvs) - 1; i >= 0; i-- {
+		kv := resp.Kvs[i]
 		branchSession := &api.BranchSession{}
 		err = branchSession.Unmarshal(kv.Value)
 		if err != nil {
@@ -369,7 +370,8 @@ func (s *store) GetBranchSessionKeys(ctx context.Context, xid string) ([]string,
 		return nil, err
 	}
 	var result []string
-	for _, kv := range branchKeyResp.Kvs {
+	for i := len(branchKeyResp.Kvs) - 1; i >= 0; i-- {
+		kv := branchKeyResp.Kvs[i]
 		result = append(result, string(kv.Value))
 	}
 	return result, nil

--- a/pkg/dt/storage/storagedriver.go
+++ b/pkg/dt/storage/storagedriver.go
@@ -37,6 +37,7 @@ type Driver interface {
 	GetBranchSessionKeys(ctx context.Context, xid string) ([]string, error)
 	BranchReport(ctx context.Context, branchID string, status api.BranchSession_BranchStatus) error
 	IsLockable(ctx context.Context, resourceID string, lockKey string) (bool, error)
+	IsLockableWithXID(ctx context.Context, resourceID string, lockKey string, xid string) (bool, error)
 	ReleaseLockKeys(ctx context.Context, resourceID string, lockKeys []string) (bool, error)
 	WatchGlobalSessions(ctx context.Context, applicationID string) Watcher
 	WatchBranchSessions(ctx context.Context, applicationID string) Watcher

--- a/pkg/filter/dt/exec/executor.go
+++ b/pkg/filter/dt/exec/executor.go
@@ -32,8 +32,14 @@ type Executor interface {
 	GetTableName() string
 }
 
-type Executable interface {
+type GlobalLockExecutor interface {
 	Executable(ctx context.Context, lockRetryInterval time.Duration, lockRetryTimes int) (bool, error)
+	GetTableMeta(ctx context.Context) (schema.TableMeta, error)
+	GetTableName() string
+}
+
+type Executable interface {
+	Executable(ctx context.Context, xid string, lockRetryInterval time.Duration, lockRetryTimes int) (bool, error)
 	GetTableMeta(ctx context.Context) (schema.TableMeta, error)
 	GetTableName() string
 }

--- a/pkg/filter/dt/exec/prepare_global_lock.go
+++ b/pkg/filter/dt/exec/prepare_global_lock.go
@@ -46,7 +46,7 @@ func NewPrepareGlobalLockExecutor(
 	isUpdate bool,
 	deleteStmt *ast.DeleteStmt,
 	updateStmt *ast.UpdateStmt,
-	args map[string]interface{}) Executable {
+	args map[string]interface{}) GlobalLockExecutor {
 	return &prepareGlobalLockExecutor{
 		conn:       conn,
 		isUpdate:   isUpdate,

--- a/pkg/filter/dt/exec/prepare_select_for_update.go
+++ b/pkg/filter/dt/exec/prepare_select_for_update.go
@@ -53,7 +53,7 @@ func NewPrepareSelectForUpdateExecutor(
 	}
 }
 
-func (executor *prepareSelectForUpdateExecutor) Executable(ctx context.Context, lockRetryInterval time.Duration, lockRetryTimes int) (bool, error) {
+func (executor *prepareSelectForUpdateExecutor) Executable(ctx context.Context, xid string, lockRetryInterval time.Duration, lockRetryTimes int) (bool, error) {
 	tableMeta, err := executor.GetTableMeta(ctx)
 	if err != nil {
 		return false, err
@@ -70,8 +70,8 @@ func (executor *prepareSelectForUpdateExecutor) Executable(ctx context.Context, 
 			err      error
 		)
 		for i := 0; i < lockRetryTimes; i++ {
-			lockable, err = dt.GetDistributedTransactionManager().IsLockable(ctx,
-				executor.conn.DataSourceName(), lockKeys)
+			lockable, err = dt.GetDistributedTransactionManager().IsLockableWithXID(ctx,
+				executor.conn.DataSourceName(), lockKeys, xid)
 			if lockable && err == nil {
 				break
 			}

--- a/pkg/filter/dt/exec/prepare_select_for_update_test.go
+++ b/pkg/filter/dt/exec/prepare_select_for_update_test.go
@@ -37,6 +37,7 @@ import (
 func TestPrepareSelectForUpdate(t *testing.T) {
 	testCases := []*struct {
 		sql                    string
+		xid                    string
 		lockInterval           time.Duration
 		lockTimes              int
 		expectedTableName      string
@@ -44,7 +45,8 @@ func TestPrepareSelectForUpdate(t *testing.T) {
 		expectedErr            error
 	}{
 		{
-			sql:                    "select /*+ GlobalLock() */ * from T where id = ? for update",
+			sql:                    "select /*+ XID('123') */ * from T where id = ? for update",
+			xid:                    "123",
 			lockInterval:           5 * time.Millisecond,
 			lockTimes:              3,
 			expectedTableName:      "`T`",
@@ -53,7 +55,7 @@ func TestPrepareSelectForUpdate(t *testing.T) {
 		},
 	}
 
-	patches1 := isLockablePatch()
+	patches1 := isLockableWithXIDPatch()
 	defer patches1.Reset()
 
 	patches2 := getPrepareTableMetaPatch()
@@ -94,7 +96,7 @@ func TestPrepareSelectForUpdate(t *testing.T) {
 			assert.Equal(t, c.expectedTableName, tableName)
 			whereCondition := executor.(*prepareSelectForUpdateExecutor).GetWhereCondition()
 			assert.Equal(t, c.expectedWhereCondition, whereCondition)
-			_, executeErr := executor.Executable(ctx, c.lockInterval, c.lockTimes)
+			_, executeErr := executor.Executable(ctx, c.xid, c.lockInterval, c.lockTimes)
 			assert.Equal(t, c.expectedErr, executeErr)
 		})
 	}

--- a/pkg/filter/dt/exec/query_global_lock_test.go
+++ b/pkg/filter/dt/exec/query_global_lock_test.go
@@ -118,7 +118,7 @@ func TestQueryGlobalLock(t *testing.T) {
 			}
 			ctx = proto.WithPrepareStmt(ctx, protoStmt)
 
-			var executor Executable
+			var executor GlobalLockExecutor
 			if c.isUpdate {
 				updateStmt := stmt.(*ast.UpdateStmt)
 				executor = NewQueryGlobalLockExecutor(&driver.BackendConnection{}, c.isUpdate, nil, updateStmt)

--- a/pkg/filter/dt/exec/query_select_for_update.go
+++ b/pkg/filter/dt/exec/query_select_for_update.go
@@ -50,7 +50,7 @@ func NewQuerySelectForUpdateExecutor(
 	}
 }
 
-func (executor *querySelectForUpdateExecutor) Executable(ctx context.Context, lockRetryInterval time.Duration, lockRetryTimes int) (bool, error) {
+func (executor *querySelectForUpdateExecutor) Executable(ctx context.Context, xid string, lockRetryInterval time.Duration, lockRetryTimes int) (bool, error) {
 	tableMeta, err := executor.GetTableMeta(ctx)
 	if err != nil {
 		return false, err
@@ -67,8 +67,8 @@ func (executor *querySelectForUpdateExecutor) Executable(ctx context.Context, lo
 			err      error
 		)
 		for i := 0; i < lockRetryTimes; i++ {
-			lockable, err = dt.GetDistributedTransactionManager().IsLockable(ctx,
-				executor.conn.DataSourceName(), lockKeys)
+			lockable, err = dt.GetDistributedTransactionManager().IsLockableWithXID(ctx,
+				executor.conn.DataSourceName(), lockKeys, xid)
 			if lockable && err == nil {
 				break
 			}

--- a/pkg/filter/dt/filter_mysql.go
+++ b/pkg/filter/dt/filter_mysql.go
@@ -149,7 +149,7 @@ func (f *_mysqlFilter) PostHandle(ctx context.Context, result proto.Result, conn
 			err = f.processAfterQueryUpdate(newCtx, bc, stmtNode)
 		case *ast.SelectStmt:
 			if stmtNode.LockInfo != nil && stmtNode.LockInfo.LockType == ast.SelectLockForUpdate {
-				err = f.processSelectForQueryUpdate(ctx, bc, result, stmtNode)
+				err = f.processQuerySelectForUpdate(ctx, bc, result, stmtNode)
 			}
 		default:
 			return nil
@@ -168,7 +168,7 @@ func (f *_mysqlFilter) PostHandle(ctx context.Context, result proto.Result, conn
 			err = f.processAfterPrepareUpdate(newCtx, bc, stmt, stmtNode)
 		case *ast.SelectStmt:
 			if stmtNode.LockInfo != nil && stmtNode.LockInfo.LockType == ast.SelectLockForUpdate {
-				err = f.processSelectForPrepareUpdate(newCtx, bc, result, stmt, stmtNode)
+				err = f.processPrepareSelectForUpdate(newCtx, bc, result, stmt, stmtNode)
 			}
 		default:
 			return nil

--- a/pkg/filter/dt/filter_mysql_prepare.go
+++ b/pkg/filter/dt/filter_mysql_prepare.go
@@ -176,13 +176,13 @@ func (f *_mysqlFilter) processAfterPrepareUpdate(ctx context.Context, conn *driv
 	return dt.GetUndoLogManager().InsertUndoLogWithNormal(conn, xid, branchID, undoLog)
 }
 
-func (f *_mysqlFilter) processSelectForPrepareUpdate(ctx context.Context, conn *driver.BackendConnection,
+func (f *_mysqlFilter) processPrepareSelectForUpdate(ctx context.Context, conn *driver.BackendConnection,
 	result proto.Result, stmt *proto.Stmt, selectStmt *ast.SelectStmt) error {
-	has, _ := misc.HasXIDHint(selectStmt.TableHints)
+	has, xid := misc.HasXIDHint(selectStmt.TableHints)
 	if !has {
 		return nil
 	}
 	executor := exec.NewPrepareSelectForUpdateExecutor(conn, selectStmt, stmt.BindVars, result)
-	_, err := executor.Executable(ctx, f.lockRetryInterval, f.lockRetryTimes)
+	_, err := executor.Executable(ctx, xid, f.lockRetryInterval, f.lockRetryTimes)
 	return err
 }

--- a/pkg/filter/dt/filter_mysql_query.go
+++ b/pkg/filter/dt/filter_mysql_query.go
@@ -174,13 +174,13 @@ func (f *_mysqlFilter) processAfterQueryUpdate(ctx context.Context, conn *driver
 	return dt.GetUndoLogManager().InsertUndoLogWithNormal(conn, xid, branchID, undoLog)
 }
 
-func (f *_mysqlFilter) processSelectForQueryUpdate(ctx context.Context, conn *driver.BackendConnection,
+func (f *_mysqlFilter) processQuerySelectForUpdate(ctx context.Context, conn *driver.BackendConnection,
 	result proto.Result, selectStmt *ast.SelectStmt) error {
-	has, _ := misc.HasXIDHint(selectStmt.TableHints)
+	has, xid := misc.HasXIDHint(selectStmt.TableHints)
 	if !has {
 		return nil
 	}
 	executor := exec.NewQuerySelectForUpdateExecutor(conn, selectStmt, result)
-	_, err := executor.Executable(ctx, f.lockRetryInterval, f.lockRetryTimes)
+	_, err := executor.Executable(ctx, xid, f.lockRetryInterval, f.lockRetryTimes)
 	return err
 }

--- a/test/sdb/distributed_transaction_test.go
+++ b/test/sdb/distributed_transaction_test.go
@@ -96,27 +96,36 @@ func (suite *_DistributedTransactionSuite) TestDistributedTransactionPrepareRequ
 		if suite.NoErrorf(err, "begin tx error: %v", err) {
 			insertSql := fmt.Sprintf(`INSERT /*+ XID('%s') */ INTO dept_manager ( id, emp_no, dept_no, from_date, to_date ) VALUES (?, ?, ?, ?, ?)`, xid)
 			result, err := tx.Exec(insertSql, 1, 100002, 1002, "2022-01-01", "2024-01-01")
-			if suite.NoErrorf(err, "insert row error: %v", err) {
+			if suite.NoErrorf(err, "insert dept_manager error: %v", err) {
 				affected, err := result.RowsAffected()
-				if suite.NoErrorf(err, "insert row error: %v", err) {
+				if suite.NoErrorf(err, "insert dept_manager error: %v", err) {
+					suite.Equal(int64(1), affected)
+				}
+			}
+
+			updateDeptManagerSql := fmt.Sprintf(`UPDATE /*+ XID('%s') */ dept_manager SET to_date = ? WHERE id = ?`, xid)
+			result, err = tx.Exec(updateDeptManagerSql, "2026-01-01", 1)
+			if suite.NoErrorf(err, "update dept_manager error: %v", err) {
+				affected, err := result.RowsAffected()
+				if suite.NoErrorf(err, "update dept_manager error: %v", err) {
 					suite.Equal(int64(1), affected)
 				}
 			}
 
 			deleteSql := fmt.Sprintf(`DELETE /*+ XID('%s') */ FROM dept_emp WHERE emp_no = ? and dept_no = ?`, xid)
 			result, err = tx.Exec(deleteSql, 100002, 1002)
-			if suite.NoErrorf(err, "delete row error: %v", err) {
+			if suite.NoErrorf(err, "delete dept_emp error: %v", err) {
 				affected, err := result.RowsAffected()
-				if suite.NoErrorf(err, "delete row error: %v", err) {
+				if suite.NoErrorf(err, "delete dept_emp error: %v", err) {
 					suite.Equal(int64(1), affected)
 				}
 			}
 
 			updateSql := fmt.Sprintf(`UPDATE /*+ XID('%s') */ salaries SET salary = ? WHERE emp_no = ?`, xid)
 			result, err = tx.Exec(updateSql, 20000, 100002)
-			if suite.NoErrorf(err, "update row error: %v", err) {
+			if suite.NoErrorf(err, "update salaries error: %v", err) {
 				affected, err := result.RowsAffected()
-				if suite.NoErrorf(err, "update row error: %v", err) {
+				if suite.NoErrorf(err, "update salaries error: %v", err) {
 					suite.Equal(int64(1), affected)
 				}
 			}
@@ -163,27 +172,36 @@ func (suite *_DistributedTransactionSuite) TestDistributedTransactionQueryReques
 		if suite.NoErrorf(err, "begin tx error: %v", err) {
 			insertSql := fmt.Sprintf(`INSERT /*+ XID('%s') */ INTO dept_manager ( id, emp_no, dept_no, from_date, to_date ) VALUES (?, ?, ?, ?, ?)`, xid)
 			result, err := tx.Exec(insertSql, 2, 100002, 1002, "2022-01-01", "2024-01-01")
-			if suite.NoErrorf(err, "insert row error: %v", err) {
+			if suite.NoErrorf(err, "insert dept_manager error: %v", err) {
 				affected, err := result.RowsAffected()
-				if suite.NoErrorf(err, "insert row error: %v", err) {
+				if suite.NoErrorf(err, "insert dept_manager error: %v", err) {
+					suite.Equal(int64(1), affected)
+				}
+			}
+
+			updateDeptManagerSql := fmt.Sprintf(`UPDATE /*+ XID('%s') */ dept_manager SET to_date = ? WHERE id = ?`, xid)
+			result, err = tx.Exec(updateDeptManagerSql, "2026-01-01", 2)
+			if suite.NoErrorf(err, "update dept_manager error: %v", err) {
+				affected, err := result.RowsAffected()
+				if suite.NoErrorf(err, "update dept_manager error: %v", err) {
 					suite.Equal(int64(1), affected)
 				}
 			}
 
 			deleteSql := fmt.Sprintf(`DELETE /*+ XID('%s') */ FROM dept_emp WHERE emp_no = ? and dept_no = ?`, xid)
 			result, err = tx.Exec(deleteSql, 100002, 1002)
-			if suite.NoErrorf(err, "delete row error: %v", err) {
+			if suite.NoErrorf(err, "delete dept_emp error: %v", err) {
 				affected, err := result.RowsAffected()
-				if suite.NoErrorf(err, "delete row error: %v", err) {
+				if suite.NoErrorf(err, "delete dept_emp error: %v", err) {
 					suite.Equal(int64(1), affected)
 				}
 			}
 
 			updateSql := fmt.Sprintf(`UPDATE /*+ XID('%s') */ salaries SET salary = ? WHERE emp_no = ?`, xid)
 			result, err = tx.Exec(updateSql, 20000, 100002)
-			if suite.NoErrorf(err, "update row error: %v", err) {
+			if suite.NoErrorf(err, "update salaries error: %v", err) {
 				affected, err := result.RowsAffected()
-				if suite.NoErrorf(err, "update row error: %v", err) {
+				if suite.NoErrorf(err, "update salaries error: %v", err) {
 					suite.Equal(int64(1), affected)
 				}
 			}


### PR DESCRIPTION
… branches

ref: https://github.com/cectc/dbpack/issues/199

### Ⅰ. Describe what this PR did


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 

there is a test case:
first:
```
insertSql := fmt.Sprintf(`INSERT /*+ XID('%s') */ INTO dept_manager ( id, emp_no, dept_no, from_date, to_date ) VALUES (?, ?, ?, ?, ?)`, xid)
result, err := tx.Exec(insertSql, 1, 100001, 1001, "2022-01-01", "2024-01-01")
```
then:
```
updateDeptManagerSql := fmt.Sprintf(`UPDATE /*+ XID('%s') */ dept_manager SET to_date = ? WHERE id = ?`, xid)
result, err = tx.Exec(updateDeptManagerSql, "2026-01-01", 1)
```
they are in a global transaction, and operate the same data. check the ci result to verify this pr.


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
