### PR TITLE
refactor: encrypted by default using AES GCM encryption algorithm

### DIFF
--- a/pkg/filter/crypto/filter.go
+++ b/pkg/filter/crypto/filter.go
@@ -38,7 +38,7 @@ import (
 
 const (
 	cryptoFilter = "CryptoFilter"
-	aesIV        = "awesome789dbpack"
+	aesIV        = "greatdbpack!"
 )
 
 type _factory struct{}
@@ -301,7 +301,7 @@ func encryptInsertValues(columns []*columnIndex, config *ColumnCrypto, valueList
 			if param, ok := arg.(*driver.ValueExpr); ok {
 				value := param.GetBytes()
 				if len(value) != 0 {
-					encoded, err := misc.AesEncryptCBC(value, []byte(config.AesKey), []byte(aesIV))
+					encoded, err := misc.AesEncryptGCM(value, []byte(config.AesKey), []byte(aesIV))
 					if err != nil {
 						return errors.Wrapf(err, "Encryption of %s failed", column.Column)
 					}
@@ -323,7 +323,7 @@ func encryptUpdateValues(updateStmt *ast.UpdateStmt, config *ColumnCrypto) error
 			if param, ok := arg.(*driver.ValueExpr); ok {
 				value := param.GetBytes()
 				if len(value) != 0 {
-					encoded, err := misc.AesEncryptCBC(value, []byte(config.AesKey), []byte(aesIV))
+					encoded, err := misc.AesEncryptGCM(value, []byte(config.AesKey), []byte(aesIV))
 					if err != nil {
 						return errors.Wrapf(err, "Encryption of %s failed", column.Column)
 					}
@@ -342,14 +342,14 @@ func encryptBindVars(columns []*columnIndex, config *ColumnCrypto, args *map[str
 		parameterID := fmt.Sprintf("v%d", column.Index+1)
 		param := (*args)[parameterID]
 		if arg, ok := param.(string); ok {
-			encoded, err := misc.AesEncryptCBC([]byte(arg), []byte(config.AesKey), []byte(aesIV))
+			encoded, err := misc.AesEncryptGCM([]byte(arg), []byte(config.AesKey), []byte(aesIV))
 			if err != nil {
 				return errors.Errorf("Encryption of %s failed: %v", column.Column, err)
 			}
 			val := hex.EncodeToString(encoded)
 			(*args)[parameterID] = val
 		} else if arg, ok := param.([]byte); ok {
-			encoded, err := misc.AesEncryptCBC(arg, []byte(config.AesKey), []byte(aesIV))
+			encoded, err := misc.AesEncryptGCM(arg, []byte(config.AesKey), []byte(aesIV))
 			if err != nil {
 				return errors.Errorf("Encryption of %s failed: %v", column.Column, err)
 			}
@@ -369,7 +369,7 @@ func decryptDecodedResult(decodedResult *mysql.DecodedResult, config *ColumnCryp
 				if protoValue != nil {
 					if originalVal, ok := protoValue.Val.([]byte); ok {
 						if n, err := hex.Decode(originalVal, originalVal); err == nil {
-							if decodedVal, err := misc.AesDecryptCBC(originalVal[:n], []byte(config.AesKey), []byte(aesIV)); err == nil {
+							if decodedVal, err := misc.AesDecryptGCM(originalVal[:n], []byte(config.AesKey), []byte(aesIV)); err == nil {
 								r.Values[column.Index].Val = decodedVal
 							}
 						}
@@ -382,7 +382,7 @@ func decryptDecodedResult(decodedResult *mysql.DecodedResult, config *ColumnCryp
 				if protoValue != nil {
 					if originalVal, ok := protoValue.Val.([]byte); ok {
 						if n, err := hex.Decode(originalVal, originalVal); err == nil {
-							if decodedVal, err := misc.AesDecryptCBC(originalVal[:n], []byte(config.AesKey), []byte(aesIV)); err == nil {
+							if decodedVal, err := misc.AesDecryptGCM(originalVal[:n], []byte(config.AesKey), []byte(aesIV)); err == nil {
 								r.Values[column.Index].Val = decodedVal
 							}
 						}

--- a/pkg/misc/crypto.go
+++ b/pkg/misc/crypto.go
@@ -26,6 +26,33 @@ import (
 	"github.com/pkg/errors"
 )
 
+func AesEncryptGCM(origData []byte, key []byte, iv []byte) (encrypted []byte, err error) {
+	var block cipher.Block
+	block, err = aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aesGcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	cipherText := aesGcm.Seal(nil, iv, origData, nil)
+	return cipherText, nil
+}
+
+func AesDecryptGCM(encrypted []byte, key []byte, iv []byte) (decrypted []byte, err error) {
+	var block cipher.Block
+	block, err = aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	aesGcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return aesGcm.Open(nil, iv, encrypted, nil)
+}
+
 func AesEncryptCBC(origData []byte, key []byte, iv []byte) (encrypted []byte, err error) {
 	var (
 		block     cipher.Block

--- a/pkg/misc/crypto_test.go
+++ b/pkg/misc/crypto_test.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2022 CECTC, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package misc
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAesEncryptGCM(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373776f726420746f206120736563726574")
+	plaintext := []byte("exampleplaintext")
+	encrypted, err := AesEncryptGCM(plaintext, key, []byte("greatdbpack!"))
+	assert.Nil(t, err)
+	t.Logf("%x", encrypted)
+}
+
+func TestAesDecryptGCM(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373776f726420746f206120736563726574")
+	encrypted, _ := hex.DecodeString("dbb2b731c2c7e9f637195ba70f85e6a26e5cbe3f536ad3457d72cf8cc4c66df1")
+	decrypted, err := AesDecryptGCM(encrypted, key, []byte("greatdbpack!"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("exampleplaintext"), decrypted)
+}
+
+func TestAesEncryptCBC(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373")
+	plaintext := []byte("exampleplaintext")
+	encrypted, err := AesEncryptCBC(plaintext, key, []byte("impressivedbpack"))
+	assert.Nil(t, err)
+	t.Logf("%x", encrypted)
+}
+
+func TestAesDecryptCBC(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373")
+	encrypted, _ := hex.DecodeString("25d5fc99f3bf7313d6f96ef83c744240d0adc7f5ad1712359ac4335b1da33a4a")
+	decrypted, err := AesDecryptCBC(encrypted, key, []byte("impressivedbpack"))
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("exampleplaintext"), decrypted)
+}
+
+func TestAesEncryptECB(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373")
+	plaintext := []byte("exampleplaintext")
+	encrypted, err := AesEncryptECB(plaintext, key)
+	assert.Nil(t, err)
+	t.Logf("%x", encrypted)
+}
+
+func TestAesDecryptECB(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373")
+	encrypted, _ := hex.DecodeString("f42512e1e4039213bd449ba47faa1b749c2f799fae8d6a326ffff2489e0a7e8a")
+	decrypted, err := AesDecryptECB(encrypted, key)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("exampleplaintext"), decrypted)
+}
+
+func TestAesEncryptCFB(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373")
+	plaintext := []byte("exampleplaintext")
+	encrypted, err := AesEncryptCFB(plaintext, key)
+	assert.Nil(t, err)
+	t.Logf("%x", encrypted)
+}
+
+func TestAesDecryptCFB(t *testing.T) {
+	key, _ := hex.DecodeString("6368616e676520746869732070617373")
+	encrypted, _ := hex.DecodeString("a5ee2fa16e5f7328fd2077a19ca0d7038bb239e498962b2b51aa40f11f9bc2d4")
+	decrypted, err := AesDecryptCFB(encrypted, key)
+	assert.Nil(t, err)
+	assert.Equal(t, []byte("exampleplaintext"), decrypted)
+}


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/24
ref: https://github.com/CECTC/dbpack/pull/202

### Ⅰ. Describe what this PR did

+ INSERT

```
INSERT INTO departments (id,dept_no,dept_name) VALUES (1,'1001','sunset')
```

will be rewrite to:

```
INSERT INTO departments (id,dept_no,dept_name) VALUES (1,'1001','8cc9106bfe893678de3588c05a2e25d086f5bfcdef06')
```

+ UPDATE
```
UPDATE departments SET dept_name='moonlight' WHERE id=1
```

will be rewrite to:

```
UPDATE departments SET dept_name='92d31176f7949f68006fdd496853d1c65131d48f760134e39c' WHERE id=1
```

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
