### PR TITLE
fix: support com_reset_connection

### DIFF
--- a/pkg/listener/mysql.go
+++ b/pkg/listener/mysql.go
@@ -820,6 +820,9 @@ func (l *MysqlListener) ExecuteCommand(ctx context.Context, c *mysql.Conn, data 
 				return err
 			}
 		}
+	case constant.ComResetConnection:
+		c.RecycleReadPacket()
+		return c.WriteOKPacket(0, 0, c.StatusFlags(), 0)
 	}
 	return nil
 }


### PR DESCRIPTION
ref: https://github.com/cectc/dbpack/issues/<issueID>

### Ⅰ. Describe what this PR did

Dotnet mysql driver 5.0.0 sent command com_reset_connection, if not handle it, will cause 
<img width="514" alt="image" src="https://user-images.githubusercontent.com/33612882/185275943-805728df-50bc-43c4-bd7b-11c3e750e50b.png">


### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
